### PR TITLE
chore: add .github/dependabot.yml for automated pip dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## What changed

Added `.github/dependabot.yml` with a `pip` package-ecosystem entry targeting the repo root on a weekly schedule.

## Why

The repository has a `pyproject.toml` with a dozen dependencies (torch, transformers, datasets, trl, wandb, pydantic, PyYAML, etc.) but no `.github` directory at all — no dependabot configuration and no CI workflows. GitHub's own security scan already flagged 4 vulnerabilities (2 moderate, 2 low) on the default branch.

Adding this minimal dependabot configuration ensures dependency updates are surfaced automatically as PRs, reducing the risk of falling behind on security patches with no manual effort required.

## Verification

```
cat /Users/minpeter/ultracode-scan/krill/.github/dependabot.yml
```

Output confirmed the file is well-formed with correct `version: 2` schema, `pip` ecosystem, root directory, and weekly schedule.

---

This is an automated maintenance pass. No existing code was modified — only a new config file was added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `.github/dependabot.yml` to enable weekly automated `pip` dependency update PRs from the repo root, capped at 10 open PRs. Keeps dependencies in `pyproject.toml` current and surfaces security fixes; no application code changed.

<sup>Written for commit 1ead2f7c4fb8d7db1098a5f58dc625e3078dfe69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/krill/pull/20?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

